### PR TITLE
ci: make deploy smoke-tests conditional (skip if BACKEND_URL/FRONTEND_URL missing)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
             cd client
             npm ci || npm install
             npm run build || echo "No build script — make sure build output is in client/ or adjust step"
-            cd -
+            cd - || true
           else
             echo "No client folder - skipping frontend build"
           fi
@@ -77,15 +77,20 @@ jobs:
           FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
         run: |
           sleep 10
-          echo "Proceeding to smoke tests (smoke tests will fail if BACKEND_URL/FRONTEND_URL are missing)"
+          echo "Proceeding to smoke tests (smoke tests will run only if BACKEND_URL & FRONTEND_URL secrets are set)"
 
-      - name: Run smoke tests (fail if BACKEND/FRONTEND not set)
+      # Run smoke tests only when both secrets are present
+      - name: Run smoke tests (only if BACKEND_URL & FRONTEND_URL secrets set)
+        if: ${{ secrets.BACKEND_URL != '' && secrets.FRONTEND_URL != '' }}
         env:
           BACKEND_URL: ${{ secrets.BACKEND_URL }}
           FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
         run: |
-          if [ -z "${BACKEND_URL:-}" ] || [ -z "${FRONTEND_URL:-}" ]; then
-            echo "BACKEND_URL or FRONTEND_URL missing — failing pipeline"
-            exit 1
-          fi
+          echo "Running smoke tests using BACKEND_URL and FRONTEND_URL from secrets"
           bash scripts/smoke_test.sh
+
+      - name: Skip smoke tests (backstop when URLs not set)
+        if: ${{ secrets.BACKEND_URL == '' || secrets.FRONTEND_URL == '' }}
+        run: |
+          echo "Skipping smoke tests because BACKEND_URL or FRONTEND_URL secret is missing."
+          echo "Set these secrets in Settings → Secrets → Actions to enable smoke tests on deploy."


### PR DESCRIPTION
Make deploy workflow skip smoke tests if BACKEND_URL / FRONTEND_URL are not configured. This avoids failing deploys while staging URLs are not yet available. See docs/ci-cd-readme.md for local smoke-test instructions.