### PR TITLE
test(auth): add auth integration tests + CI skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Check frontend presence
+        id: check_client
         run: |
-          if [ -d client ] || [ -f client/index.html ]; then
-            echo "frontend present"
+          if [ -d client ] && [ -f client/package.json ]; then
+            echo "has_client=true" >> $GITHUB_OUTPUT
           else
-            echo "No frontend; skipping frontend checks"
+            echo "has_client=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Setup Node (only if frontend exists)
+        if: steps.check_client.outputs.has_client == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install & Run frontend tests
+        if: steps.check_client.outputs.has_client == 'true'
+        run: |
+          cd client
+          npm ci || npm install
+          # run tests (allow them to fail without failing overall CI if you prefer)
+          npm test --silent
 
   backend-check:
     name: backend-check
@@ -29,25 +45,62 @@ jobs:
           POSTGRES_DB: test_db
         options: >-
           --health-cmd pg_isready --health-interval=10s --health-timeout=5s --health-retries=5
-
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+
       - name: Install backend deps if present
         run: |
           if [ -f server/requirements.txt ]; then
             python -m pip install --upgrade pip
             pip install -r server/requirements.txt
+          elif [ -f requirements.txt ]; then
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
           else
-            echo "No server/requirements.txt found; skipping install"
+            echo "No requirements file found; skipping install"
           fi
-      - name: Backend sanity import (if present)
+
+      - name: Wait for Postgres
         run: |
-          if [ -f server/app.py ]; then
-            python -c "import sys; sys.path.append('server'); import app; print('import OK')"
+          # Wait for the postgres service to be healthy (pg_isready), retry if needed
+          for i in {1..15}; do
+            pg_isready -h localhost -p 5432 && break
+            echo "Waiting for postgres..."
+            sleep 2
+          done
+
+      - name: Set test env vars
+        env:
+          # service is accessible at localhost:5432
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+        run: |
+          echo "TEST_DATABASE_URL=${TEST_DATABASE_URL}" >> $GITHUB_ENV
+          # Provide a default JWT secret for tests if none in secrets
+          echo "JWT_SECRET=${{ secrets.JWT_SECRET || 'test-jwt-secret' }}" >> $GITHUB_ENV
+
+      - name: Run DB migrations (if alembic present)
+        run: |
+          if [ -f alembic.ini ] || [ -d alembic ]; then
+            pip install alembic || true
+            export DATABASE_URL=${TEST_DATABASE_URL}
+            alembic upgrade head || echo "alembic upgrade failed (continue)"
           else
-            echo "No server/app.py; skipping import check"
+            echo "No alembic config - skipping migrations"
+          fi
+
+      - name: Run backend tests (pytest)
+        env:
+          TEST_DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+          JWT_SECRET: ${{ env.JWT_SECRET }}
+        run: |
+          # run pytest if tests exist
+          if [ -d tests ] || ls tests/*.py >/dev/null 2>&1; then
+            pytest -q
+          else
+            echo "No tests folder found; skipping pytest"
           fi

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,47 @@
+import os
+from typing import Optional, Dict, Any
+
+# Prefer an existing create_app in server/app.py if present
+try:
+    from .app import create_app as _app_create
+except Exception:
+    _app_create = None
+
+from .extensions import db, migrate
+
+
+def create_app(config: Optional[Dict[str, Any]] = None):
+    """
+    App factory used by tests and scripts. If server/app.py defines create_app()
+    delegate to it; otherwise create a minimal Flask app.
+    """
+    if _app_create:
+        app = _app_create()
+        if config:
+            app.config.update(config)
+        # ensure extensions are initialized (no-op if app did it)
+        try:
+            db.init_app(app)
+            migrate.init_app(app, db)
+        except Exception:
+            pass
+        return app
+
+    # Minimal fallback factory
+    from flask import Flask
+    app = Flask(__name__, instance_relative_config=False)
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", os.environ.get("DATABASE_URL", "sqlite:///:memory:"))
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+
+    
+    @app.route("/_health")
+    def _health():
+        return {"status": "ok"}
+
+    return app

--- a/server/extensions.py
+++ b/server/extensions.py
@@ -1,0 +1,5 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+
+db = SQLAlchemy()
+migrate = Migrate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from server import create_app
+from server.extensions import db as _db
+
+TEST_DB_URI = os.environ.get("TEST_DATABASE_URL", "sqlite:///:memory:")
+
+
+@pytest.fixture(scope="session")
+def app():
+    config = {
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": TEST_DB_URI,
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        "JWT_SECRET": os.environ.get("JWT_SECRET", "test-jwt-secret"),
+    }
+    app = create_app(config)
+    return app
+
+
+@pytest.fixture(scope="session")
+def _db_app(app):
+    
+    # Create the database and the database tables
+    with app.app_context():
+        _db.create_all()
+        yield _db
+        _db.session.remove()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app, _db_app):
+    return app.test_client()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,70 @@
+import json
+import pytest
+
+REGISTER_URL = "/api/auth/register"
+LOGIN_URL = "/api/auth/login"
+ME_URL = "/api/users/me"
+
+
+def register_user(client, name="Test User", email="test@example.com", password="password123"):
+    payload = {"name": name, "email": email, "password": password}
+    r = client.post(REGISTER_URL, json=payload)
+    return r
+
+
+def login_user(client, email="test@example.com", password="password123"):
+    payload = {"email": email, "password": password}
+    r = client.post(LOGIN_URL, json=payload)
+    return r
+
+
+def get_auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def assert_user_shape(obj):
+    assert isinstance(obj, dict)
+    assert "id" in obj or "email" in obj
+    assert "email" in obj or "name" in obj
+
+
+def test_register_login_and_get_me(client):
+    r = register_user(client)
+    assert r.status_code in (200, 201), f"unexpected status {r.status_code} body={r.get_data(as_text=True)}"
+    data = r.get_json()
+    assert isinstance(data, dict)
+    assert ("token" in data) or ("user" in data)
+    token = data.get("token") or (data.get("user") or {}).get("token")
+    if token is None and isinstance(data.get("user"), dict):
+        token = data["user"].get("token")
+
+    if not token:
+        r2 = login_user(client)
+        assert r2.status_code == 200, f"login failed after register: {r2.get_data(as_text=True)}"
+        token = r2.get_json().get("token")
+
+    assert token, "token not returned by register/login"
+
+    headers = get_auth_headers(token)
+    r_me = client.get(ME_URL, headers=headers)
+    assert r_me.status_code == 200, f"/api/users/me failed: {r_me.status_code} {r_me.get_data(as_text=True)}"
+    me = r_me.get_json()
+    assert isinstance(me, dict)
+    assert "email" in me or "name" in me
+    assert_user_shape(me)
+
+
+def test_login_returns_token_and_invalid_credentials_are_rejected(client):
+    register_user(client, email="login-test@example.com")
+    r = login_user(client, email="login-test@example.com")
+    assert r.status_code == 200, f"login should succeed, got {r.status_code}"
+    data = r.get_json()
+    assert "token" in data or ("user" in data and data["user"].get("token"))
+
+    r_bad = login_user(client, email="login-test@example.com", password="wrongpass")
+    assert r_bad.status_code in (400, 401), f"expected auth failure, got {r_bad.status_code}"
+
+
+def test_protected_route_requires_auth(client):
+    r = client.get(ME_URL)
+    assert r.status_code in (401, 403), f"expected 401/403 for unauthenticated, got {r.status_code}"


### PR DESCRIPTION
What I have done:

Added auth integration tests and a minimal CI/test scaffold.

What’s included
- tests/test_auth.py (POST /api/auth/register, POST /api/auth/login, GET /api/users/me)
- tests/conftest.py (fixtures)
- small app shim so tests run in CI

Status
- Tests currently fail because auth endpoints / User model are not implemented.

Action requested
- @BrianOduory: please implement User model + endpoints on a feature branch. Don’t change schema without coordinating, I’ll create migrations after the model is pushed.